### PR TITLE
Closes issue#2

### DIFF
--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -3,11 +3,20 @@ version: "3.9"
 # Describes containers (services) that make up the environment.
 services: 
   rabbitmq:
-    # Official RabbitMQ image from Docker Hub including management UI
+    # Official RabbitMQ image from Docker Hub including management UI.
     image: rabbitmq:3.8.14-management
-    # Publish ports to the outside world - bindng container port to host port (hostport:containerport)
+    # Publish ports to the outside world - bindng container port to host port (hostport:containerport).
     ports:
       # Standard AMQP protocol port
       - 5672:5672
       # RabbitMQ management port
       - 15672:15672
+    # Which custom Docker networks service should join.
+    networks: 
+      - rabbit-network
+
+# Docker Compose automatically creates a default network that all services joins, so they communicate with each other.
+# This section describes custom Docker networks that individual services can join.
+networks:
+  rabbit-network:
+    driver: bridge

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -3,9 +3,11 @@ version: "3.9"
 # Describes containers (services) that make up the environment.
 services: 
   rabbitmq:
-    # Official RabbitMQ image from Docker Hub
-    image: rabbitmq:3.8.14
+    # Official RabbitMQ image from Docker Hub including management UI
+    image: rabbitmq:3.8.14-management
     # Publish ports to the outside world - bindng container port to host port (hostport:containerport)
     ports:
       # Standard AMQP protocol port
       - 5672:5672
+      # RabbitMQ management port
+      - 15672:15672

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -5,6 +5,10 @@ services:
   rabbitmq:
     # Official RabbitMQ image from Docker Hub including management UI.
     image: rabbitmq:3.8.14-management
+    # Override service name being used as container name
+    container_name: rabbit-node-1
+    # Override default hostname (container ID)
+    hostname: rabbit-node-1
     # Publish ports to the outside world - bindng container port to host port (hostport:containerport).
     ports:
       # Standard AMQP protocol port

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+# Describes containers (services) that make up the environment.
+services: 
+  rabbitmq:
+    # Official RabbitMQ image from Docker Hub
+    image: rabbitmq:3.8.14
+    # Publish ports to the outside world - bindng container port to host port (hostport:containerport)
+    ports:
+      # Standard AMQP protocol port
+      - 5672:5672


### PR DESCRIPTION
This pull request fixes issue#2 with a Docker Compose file that describes a RabbitMQ service based on the official RabbitMQ Docker image from Docker Hub. The chosen RabbitMQ image includes the RabbitMQ management UI plug-in for easy management of RabbitMQ. Port 5672 is published for AMQP protocol interaction from external services. Port 15672 is published for use of the management UI. 

Run the command docker-compose up -d inside of the rabbitmq folder and go to localhost:15672 to see the RabbitMQ management UI.