### PR TITLE
Fixes Issue#1

### DIFF
--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - 2181:2181
     environment: 
       ZOO_MY_ID: 1
+    networks: 
+      - kafka-network
 
   kafka:
     # Popular Docker image for Apache Kafka that downloads Kafka from Apache's official Kafka website.
@@ -28,3 +30,9 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_BROKER_ID: 1
       KAFKA_ADVERTISED_HOST_NAME: localhost # Must be changed later when connecting from containerized services
+    networks: 
+      - kafka-network
+
+networks: 
+  kafka-network:
+    driver: bridge

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -18,9 +18,13 @@ services:
     image: wurstmeister/kafka:2.13-2.7.0
     container_name: kafka-broker-1
     hostname: kafka-broker-1
+    depends_on:
+      # Kafka depends on Zookeeper. This makes sure that the Zookeeper container starts before the Kafka container
+      - zookeeper
     ports:
       # Default port for Kafka server.
       - 9092:9092
     environment: 
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
       KAFKA_ADVERTISED_HOST_NAME: localhost # Must be changed later when connecting from containerized services

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  zookeeper:
+    # Official Zookeeper image from Docker Hub.
+    image: zookeeper:3.6.2
+    container_name: zookeeper-node-1
+    hostname: zookeeper-node-1
+    ports: 
+      # Standard Zookeeper port which the clients connect to.
+      - 2181:2181
+    environment: 
+      ZOO_MY_ID: 1

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -11,3 +11,16 @@ services:
       - 2181:2181
     environment: 
       ZOO_MY_ID: 1
+
+  kafka:
+    # Popular Docker image for Apache Kafka that downloads Kafka from Apache's official Kafka website.
+    # Kafka version specified by tag in format: <scala version>-<kafka version>
+    image: wurstmeister/kafka:2.13-2.7.0
+    container_name: kafka-broker-1
+    hostname: kafka-broker-1
+    ports:
+      # Default port for Kafka server.
+      - 9092:9092
+    environment: 
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_HOST_NAME: localhost # Must be changed later when connecting from containerized services


### PR DESCRIPTION
This pull request fixes issue#1 by adding a Docker Compose file that describes Kafka and Zookeeper as services.

1. Run the command `docker-compose up -d` inside of the kafka folder. 
2. Shell into Kafka Docker container: `docker exec -it kafka-broker-1 sh`
3. Create a topic to test Kafka and its connection to Zookeeper: `/opt/kafka/bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 1 --topic test-topic`
4. Created topic test-topic should appear.

**Documentation purposes**
Usually at least 3 Zookeeper nodes and at least 3 Kafka brokers are used. 6 containers would have to be spun up then, which would use a lot of computer resources that might be needed for the experiments scaling of producers. Right now, only one Zookeeper node and only one Kafka broker is used, but it might be changed later. RabbitMQ could also be scaled to 3 nodes for example to get something similar.

The official Zookeeper image (https://hub.docker.com/_/zookeeper) was used. Kafka does not have an official image, but there are several popular ones: wurstmeister (https://hub.docker.com/r/wurstmeister/kafka), bitnami (https://hub.docker.com/r/bitnami/kafka/) and confluentinc (https://hub.docker.com/r/confluentinc/cp-kafka/).

The creators of Kafka started up Confluent and they provide Confluent platform which evolves around Kafka with the possibility of extending it in many ways (Schema Registry, kSQL, Rest Proxy etc.). But for this thesis project, only the basic Apache Kafka is intended to be tested and I do not know right now if the cp-kafka image from Confluent has any difference from a normal Apache Kafka distribution. 

The image from wurstmeister was chosen since it can clearly be seen on the GitHub page (https://github.com/wurstmeister/kafka-docker) that it downloads Kafka from the official apache website.

It is possible that the Kafka image used changes in the future. For example, Bitnami has Docker images for all the services that are needed for the project (RabbitMQ, Kafka and Zookeeper). So maybe it would be better to use Bitnami images for every service even if RabbitMQ and Zookeeper has Docker images marked as official on DockerHub.