### PR TITLE
Closes Issue#11

### DIFF
--- a/rabbitmq/consumer-service/.dockerignore
+++ b/rabbitmq/consumer-service/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+node_modules

--- a/rabbitmq/consumer-service/Dockerfile
+++ b/rabbitmq/consumer-service/Dockerfile
@@ -1,0 +1,17 @@
+# Use official Node.js Docker image as base image to include all its functionality
+FROM node:14.16.0-alpine
+
+# Create working directory in container and set it as default location for subsequent commands
+WORKDIR /consumer-service
+
+# Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
+COPY package*.json ./
+
+# Install dependencies specified in package.json
+RUN npm install
+
+# Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
+COPY . ./
+
+# Command to execute when container instance is created based on image (starts application in container)
+CMD [ "npm", "run", "start" ]

--- a/rabbitmq/consumer-service/consumer-service.js
+++ b/rabbitmq/consumer-service/consumer-service.js
@@ -4,7 +4,7 @@ const QUEUE_NAME = "test-queue";
 
 const amqpConnectionSettings = {
   protocol: "amqp",
-  hostname: "localhost",
+  hostname: "rabbit-node-1",
   port: 5672,
   username: "guest",
   password: "guest",

--- a/rabbitmq/consumer-service/package.json
+++ b/rabbitmq/consumer-service/package.json
@@ -4,7 +4,7 @@
   "description": "Consumer service for RabbitMQ",
   "main": "consumer-service.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node consumer-service.js"
   },
   "keywords": [],
   "author": "a18antsv",

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 
 # Describes containers (services) that make up the environment.
 services: 
+
   rabbitmq:
     # Official RabbitMQ image from Docker Hub including management UI.
     image: rabbitmq:3.8.14-management
@@ -16,6 +17,23 @@ services:
       # RabbitMQ management port
       - 15672:15672
     # Which custom Docker networks service should join.
+    networks: 
+      - rabbit-network
+  
+  producer:
+    # Relative path to a directory that contains a Dockerfile to build an image from.
+    build: ./producer-service/.
+    container_name: rabbit-producer-service
+    depends_on: 
+      - rabbitmq
+    networks: 
+      - rabbit-network
+  
+  consumer:
+    build: ./consumer-service/.
+    container_name: rabbit-consumer-service
+    depends_on: 
+      - rabbitmq
     networks: 
       - rabbit-network
 

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     # Relative path to a directory that contains a Dockerfile to build an image from.
     build: ./producer-service/.
     container_name: rabbit-producer-service
+    # It takes some time for RabbitMQ to start up and get ready for incoming TCP-connections.
+    # This will make the producer and consumer services crash as the connection is refused.
+    # Indefinitely restarting the containers when they stop is a temporary fix.
+    # A better fix should be made in another issue by using Docker healthcheck for example.
+    restart: unless-stopped
     depends_on: 
       - rabbitmq
     networks: 
@@ -32,6 +37,7 @@ services:
   consumer:
     build: ./consumer-service/.
     container_name: rabbit-consumer-service
+    restart: unless-stopped
     depends_on: 
       - rabbitmq
     networks: 

--- a/rabbitmq/producer-service/.dockerignore
+++ b/rabbitmq/producer-service/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+node_modules

--- a/rabbitmq/producer-service/Dockerfile
+++ b/rabbitmq/producer-service/Dockerfile
@@ -1,2 +1,17 @@
 # Use official Node.js Docker image as base image to include all its functionality
 FROM node:14.16.0-alpine
+
+# Create working directory in container and set it as default location for subsequent commands
+WORKDIR /producer-service
+
+# Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
+COPY package*.json ./
+
+# Install dependencies specified in package.json
+RUN npm install
+
+# Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
+COPY . ./
+
+# Command to execute when container instance is created based on image (starts application in container)
+CMD [ "npm", "run", "start" ]

--- a/rabbitmq/producer-service/Dockerfile
+++ b/rabbitmq/producer-service/Dockerfile
@@ -1,0 +1,2 @@
+# Use official Node.js Docker image as base image to include all its functionality
+FROM node:14.16.0-alpine

--- a/rabbitmq/producer-service/package.json
+++ b/rabbitmq/producer-service/package.json
@@ -4,7 +4,7 @@
   "description": "Producer service for RabbitMQ",
   "main": "producer-service.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node producer-service.js"
   },
   "keywords": [],
   "author": "a18antsv",

--- a/rabbitmq/producer-service/producer-service.js
+++ b/rabbitmq/producer-service/producer-service.js
@@ -9,7 +9,7 @@ const MESSAGE = process.argv[2] || "test-message";
 
 const amqpConnectionSettings = {
   protocol: "amqp",
-  hostname: "localhost",
+  hostname: "rabbit-node-1",
   port: 5672,
   username: "guest",
   password: "guest",


### PR DESCRIPTION
Containerized producer and consumer services for RabbitMQ and included the services in the Docker Compose file for easy startup of everything. 
Run the command `docker-compose up -d` inside of the rabbitmq folder to start everything.

### Documentation purposes
The service images can also be manually built by the commands `docker build --tag rabbit-consumer-service-image .` and `docker build --tag rabbit-producer-service-image .` The commands has to be run within the context of the service Dockerfile.
Then create and run a container based on the images with the commands `docker run -d --network rabbitmq_rabbit-network --name rabbit-consumer-service-1 rabbit-consumer-service-image` and `docker run -d --network rabbitmq_rabbit-network --name rabbit-producer-service-1 rabbit-producer-service-image`. The Docker network has to be specified to be able to communicate with RabbitMQ. With Docker Compose these commands are no longer needed but can be good to have documented.

A problem is that it takes some time for RabbitMQ to get ready for incoming TCP-connections. This makes the producer and consumer services crash since the connection is refused. A temporary fix was made by restarting the containers if they go down, except for when the containers were intentionally stopped. This is not the best solution since the containers will make several attempts at connection to RabbitMQ without success and crashing before everything starts to work when RabbitMQ is ready. This should be fixed in another issue by making the services wait until the RabbitMQ service is completely up and running before the connection to RabbitMQ is attempted to be made.