### PR TITLE
Closes Issue#12

### DIFF
--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -1,0 +1,17 @@
+# Use official Node.js Docker image as base image to include all its functionality
+FROM node:14.16.0-alpine
+
+# Create working directory in container and set it as default location for subsequent commands
+WORKDIR /consumer-service
+
+# Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
+COPY package*.json ./
+
+# Install dependencies specified in package.json
+RUN npm install
+
+# Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
+COPY . ./
+
+# Command to execute when container instance is created based on image (starts application in container)
+CMD [ "npm", "run", "start" ]

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -2,7 +2,9 @@ import { Kafka } from "kafkajs";
 
 const kafka = new Kafka({
   clientId: "consumer-service-1",
-  brokers: ["localhost:9092"]
+  brokers: [
+    "kafka-broker-1:9092"
+  ]
 });
 
 // Create a consumer that joins a consumer group (required)

--- a/kafka/consumer-service/package.json
+++ b/kafka/consumer-service/package.json
@@ -4,7 +4,7 @@
   "description": "Consumer service for Kafka",
   "main": "consumer-service.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node consumer-service.js"
   },
   "keywords": [],
   "author": "a18antsv",

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -41,6 +41,25 @@ services:
     networks: 
       - kafka-network
 
+  producer:
+    # Relative path to a directory that contains a Dockerfile to build an image from.
+    build: ./producer-service/.
+    container_name: kafka-producer-service
+    depends_on: 
+      - zookeeper
+      - kafka
+    networks: 
+      - kafka-network
+  
+  consumer:
+    build: ./consumer-service/.
+    container_name: kafka-consumer-service
+    depends_on: 
+      - zookeeper
+      - kafka
+    networks: 
+      - kafka-network
+
 networks: 
   kafka-network:
     driver: bridge

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-broker-1:9092,EXTERNAL://localhost:19092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      # Create test topic with 1 partition and replication factor 1 if it does not already exists (special for the wurstmeister Kafka image)
+      KAFKA_CREATE_TOPICS: test-topic:1:1
     networks: 
       - kafka-network
 

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -24,12 +24,20 @@ services:
       # Kafka depends on Zookeeper. This makes sure that the Zookeeper container starts before the Kafka container
       - zookeeper
     ports:
-      # Default port for Kafka server.
-      - 9092:9092
+      # Bind container port to host port (hostport:containerport).
+      - 19092:19092
     environment: 
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_BROKER_ID: 1
-      KAFKA_ADVERTISED_HOST_NAME: localhost # Must be changed later when connecting from containerized services
+      # How kafka nodes communicate.
+      KAFKA_LISTENERS: INTERNAL://kafka-broker-1:9092,EXTERNAL://kafka-broker-1:19092
+      # How clients connect. 
+      # INTERNAL listener for traffic from the internal Docker network.
+      # EXTERNAL listener for traffic coming from outside Docker network, but still only from Docker-host machine.
+      # EXTERNAL listener used during testing to be able to use Kafka VScode extension to test the Kafka cluster.
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-broker-1:9092,EXTERNAL://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
     networks: 
       - kafka-network
 

--- a/kafka/producer-service/Dockerfile
+++ b/kafka/producer-service/Dockerfile
@@ -1,0 +1,17 @@
+# Use official Node.js Docker image as base image to include all its functionality
+FROM node:14.16.0-alpine
+
+# Create working directory in container and set it as default location for subsequent commands
+WORKDIR /producer-service
+
+# Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
+COPY package*.json ./
+
+# Install dependencies specified in package.json
+RUN npm install
+
+# Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
+COPY . ./
+
+# Command to execute when container instance is created based on image (starts application in container)
+CMD [ "npm", "run", "start" ]

--- a/kafka/producer-service/package.json
+++ b/kafka/producer-service/package.json
@@ -4,7 +4,7 @@
   "description": "Producer service for Kafka",
   "main": "producer-service.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node producer-service.js"
   },
   "keywords": [],
   "author": "a18antsv",

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -8,7 +8,9 @@ const MESSAGE_OBJECT = {
 
 const kafka = new Kafka({
   clientId: "producer-service-1",
-  brokers: ["localhost:9092"]
+  brokers: [ 
+    "kafka-broker-1:9092" 
+  ]
 });
 const producer = kafka.producer();
 
@@ -17,7 +19,9 @@ const producer = kafka.producer();
 
   await producer.send({
     topic: TOPIC_NAME,
-    messages: [ MESSAGE_OBJECT ],
+    messages: [
+      MESSAGE_OBJECT
+    ],
     acks: -1, // 0 = no acks, 1 = Only leader, -1 = All insync replicas
     timeout: 30000,
     compression: CompressionTypes.None,


### PR DESCRIPTION
Containerized Kafka producer and consumer services and added them to Docker Compose. The producer service still only produces one message and then shuts down. So the producer service can be started several times and to see the messages consumed check the output of the consumer service. Run `docker-compose up` within the context of the docker-compose  file for Kafka.

### Documentation purposes
The service images can also be manually built by the commands `docker build --tag kafka-consumer-service-image .` and `docker build --tag kafka-producer-service-image .` The commands has to be run within the context of the service Dockerfile.
Then create and run a container based on the images with the commands `docker run -d --network kafka_rabbit-network --name kafka-consumer-service-1 kafka-consumer-service-image` and `docker run -d --network kafka_kafka-network --name kafka-producer-service-1 kafka-producer-service-image`. The Docker network has to be specified to be able to communicate with Kafka. With Docker Compose these commands are no longer needed but it can be good to have them documented.