### PR TITLE
Closes Issue#23

### DIFF
--- a/kafka/consumer-service/.dockerignore
+++ b/kafka/consumer-service/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+node_modules
+.dockerignore

--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -2,16 +2,16 @@
 FROM node:14.16.0-alpine
 
 # Create working directory in container and set it as default location for subsequent commands
-WORKDIR /consumer-service
+WORKDIR /usr/src/consumer-service
 
 # Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
-COPY package*.json ./
+COPY ./kafka/consumer-service/package*.json ./
 
 # Install dependencies specified in package.json
 RUN npm install
 
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
-COPY . ./
+COPY ./kafka/consumer-service/ ./
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./kafka/consumer-service/ ./
 
+# Test to copy 
+COPY ./shared/test.txt ./
+
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -44,8 +44,11 @@ services:
       - kafka-network
 
   producer:
-    # Relative path to a directory that contains a Dockerfile to build an image from.
-    build: ./producer-service/.
+    build:
+      # Use root directory as build context to allow for copying of files from shared folders
+      context: ../
+      # Relative path to a Dockerfile to build an image from.
+      dockerfile: ./kafka/producer-service/Dockerfile
     container_name: kafka-producer-service
     depends_on: 
       - zookeeper
@@ -54,7 +57,9 @@ services:
       - kafka-network
   
   consumer:
-    build: ./consumer-service/.
+    build:
+      context: ../
+      dockerfile: ./kafka/consumer-service/Dockerfile
     container_name: kafka-consumer-service
     depends_on: 
       - zookeeper

--- a/kafka/producer-service/.dockerignore
+++ b/kafka/producer-service/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+node_modules
+.dockerignore

--- a/kafka/producer-service/Dockerfile
+++ b/kafka/producer-service/Dockerfile
@@ -2,16 +2,16 @@
 FROM node:14.16.0-alpine
 
 # Create working directory in container and set it as default location for subsequent commands
-WORKDIR /producer-service
+WORKDIR /usr/src/producer-service
 
 # Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
-COPY package*.json ./
+COPY ./kafka/producer-service/package*.json ./
 
 # Install dependencies specified in package.json
 RUN npm install
 
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
-COPY . ./
+COPY ./kafka/producer-service/ ./
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/rabbitmq/consumer-service/Dockerfile
+++ b/rabbitmq/consumer-service/Dockerfile
@@ -2,16 +2,16 @@
 FROM node:14.16.0-alpine
 
 # Create working directory in container and set it as default location for subsequent commands
-WORKDIR /consumer-service
+WORKDIR /usr/src/consumer-service
 
 # Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
-COPY package*.json ./
+COPY ./rabbitmq/consumer-service/package*.json ./
 
 # Install dependencies specified in package.json
 RUN npm install
 
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
-COPY . ./
+COPY ./rabbitmq/consumer-service/ ./
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -21,8 +21,11 @@ services:
       - rabbit-network
   
   producer:
-    # Relative path to a directory that contains a Dockerfile to build an image from.
-    build: ./producer-service/.
+    build: 
+      # Use root directory as build context to allow for copying of files from shared folders
+      context: ../
+      # Relative path to a Dockerfile to build an image from.
+      dockerfile: ./rabbitmq/producer-service/Dockerfile
     container_name: rabbit-producer-service
     # It takes some time for RabbitMQ to start up and get ready for incoming TCP-connections.
     # This will make the producer and consumer services crash as the connection is refused.
@@ -35,7 +38,9 @@ services:
       - rabbit-network
   
   consumer:
-    build: ./consumer-service/.
+    build: 
+      context: ../
+      dockerfile: ./rabbitmq/consumer-service/Dockerfile
     container_name: rabbit-consumer-service
     restart: unless-stopped
     depends_on: 

--- a/rabbitmq/producer-service/Dockerfile
+++ b/rabbitmq/producer-service/Dockerfile
@@ -2,16 +2,16 @@
 FROM node:14.16.0-alpine
 
 # Create working directory in container and set it as default location for subsequent commands
-WORKDIR /producer-service
+WORKDIR /usr/src/producer-service
 
 # Copy package.json and package-lock.json in separate layer to facilitate caching as dependencies do not change often
-COPY package*.json ./
+COPY ./rabbitmq/producer-service/package*.json ./
 
 # Install dependencies specified in package.json
 RUN npm install
 
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
-COPY . ./
+COPY ./rabbitmq/producer-service/ ./
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/shared/test.txt
+++ b/shared/test.txt
@@ -1,0 +1,1 @@
+This is a textfile that will can be copied into different services after the build context change.


### PR DESCRIPTION
The build context has been changed for both Kafka and RabbitMQ, making it possible to copy shared files from anywhere within the root folder to any service container.