### PR TITLE
Closes Issue#22

### DIFF
--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./kafka/consumer-service/ ./
 
+# Copy shared utils file to set image working directory
+COPY ./shared/utils.mjs ./
+
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -13,8 +13,5 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./kafka/consumer-service/ ./
 
-# Test to copy 
-COPY ./shared/test.txt ./
-
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -18,21 +18,17 @@ const consumer = kafka.consumer({
 });
 
 (async () => {
-  let [error, _] = [undefined, undefined];
-
-  [error] = await handler(consumer.connect());
-
-  if(error) {
+  const [connectionError] = await handler(consumer.connect());
+  if(connectionError) {
     return console.error("Could not connect to Kafka...");
   }
 
   // Subscribe consumer group to topic and start using latest offset
-  [error] = await handler(consumer.subscribe({
+  const [subscribeError] = await handler(consumer.subscribe({
     topic: TOPIC_NAME,
     fromBeginning: false
   }));
-  
-  if(!error) {
+  if(!subscribeError) {
     console.log(`Successfully subscribed to topic ${TOPIC_NAME}!`);
   }
   

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -1,4 +1,9 @@
 import { Kafka } from "kafkajs";
+import { 
+  promiseHandler as handler
+} from "./utils.mjs";
+
+const TOPIC_NAME = "test-topic";
 
 const kafka = new Kafka({
   clientId: "consumer-service-1",
@@ -13,16 +18,26 @@ const consumer = kafka.consumer({
 });
 
 (async () => {
-  await consumer.connect();
+  let [error, _] = [undefined, undefined];
+
+  [error] = await handler(consumer.connect());
+
+  if(error) {
+    return console.error("Could not connect to Kafka...");
+  }
 
   // Subscribe consumer group to topic and start using latest offset
-  await consumer.subscribe({
-    topic: "test-topic",
+  [error] = await handler(consumer.subscribe({
+    topic: TOPIC_NAME,
     fromBeginning: false
-  });
+  }));
+  
+  if(!error) {
+    console.log(`Successfully subscribed to topic ${TOPIC_NAME}!`);
+  }
   
   // Run consumer and handle one message at a time
-  consumer.run({
+  await handler(consumer.run({
     eachMessage: async ({ topic, partition, message }) => {
       const { 
         stationId,
@@ -48,6 +63,5 @@ const consumer = kafka.consumer({
           - SO2 ${concentrations.so2}
       `);
     }
-  });
-  
+  }));
 })();

--- a/kafka/producer-service/Dockerfile
+++ b/kafka/producer-service/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./kafka/producer-service/ ./
 
+# Copy shared utils file to set image working directory
+COPY ./shared/utils.mjs ./
+
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -1,6 +1,7 @@
 import { CompressionTypes, Kafka } from "kafkajs";
-
-const TOPIC_NAME = "test-topic";
+import { 
+  promiseHandler as handler
+} from "./utils.mjs";
 
 const airQualityObservation = {
   stationId: "air_station_01",
@@ -19,6 +20,8 @@ const airQualityObservation = {
   }
 };
 
+const TOPIC_NAME = "test-topic";
+
 const MESSAGE_OBJECT = {
   key: "air_station_01",
   value: JSON.stringify(airQualityObservation),
@@ -33,9 +36,17 @@ const kafka = new Kafka({
 const producer = kafka.producer();
 
 (async () => {
-  await producer.connect();
+  // Array as returned by promise handler utility function.
+  let [error, response] = [undefined, undefined];
+  
+  // Some promises return void when resolving, making the response undefined and not necessary to destructure.
+  [error] = await handler(producer.connect());
 
-  await producer.send({
+  if(error) {
+    return console.error("Could not connect to Kafka...");
+  }
+
+  [error, response] = await handler(producer.send({
     topic: TOPIC_NAME,
     messages: [
       MESSAGE_OBJECT
@@ -43,9 +54,13 @@ const producer = kafka.producer();
     acks: -1, // 0 = no acks, 1 = Only leader, -1 = All insync replicas
     timeout: 30000,
     compression: CompressionTypes.None,
-  });
+  }));
 
-  await producer.disconnect();
+  if(!error) {
+    console.log(`Successfully sent message! Response: ${JSON.stringify(response)}`);
+  }
+
+  await handler(producer.disconnect());
 
   process.exit(0);
 })();

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -36,17 +36,13 @@ const kafka = new Kafka({
 const producer = kafka.producer();
 
 (async () => {
-  // Array as returned by promise handler utility function.
-  let [error, response] = [undefined, undefined];
-  
   // Some promises return void when resolving, making the response undefined and not necessary to destructure.
-  [error] = await handler(producer.connect());
-
-  if(error) {
+  const [connectionError] = await handler(producer.connect());
+  if(connectionError) {
     return console.error("Could not connect to Kafka...");
   }
 
-  [error, response] = await handler(producer.send({
+  const [sendError, producerRecordMetadata] = await handler(producer.send({
     topic: TOPIC_NAME,
     messages: [
       MESSAGE_OBJECT
@@ -56,8 +52,8 @@ const producer = kafka.producer();
     compression: CompressionTypes.None,
   }));
 
-  if(!error) {
-    console.log(`Successfully sent message! Response: ${JSON.stringify(response)}`);
+  if(!sendError) {
+    console.log(`Successfully sent message! Response: ${JSON.stringify(producerRecordMetadata)}`);
   }
 
   await handler(producer.disconnect());

--- a/rabbitmq/consumer-service/Dockerfile
+++ b/rabbitmq/consumer-service/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./rabbitmq/consumer-service/ ./
 
+# Copy shared utils file to set image working directory
+COPY ./shared/utils.mjs ./
+
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/rabbitmq/producer-service/Dockerfile
+++ b/rabbitmq/producer-service/Dockerfile
@@ -13,5 +13,8 @@ RUN npm install
 # Copy the rest of the files in the same directory as the Dockerfile to the set image working directory
 COPY ./rabbitmq/producer-service/ ./
 
+# Copy shared utils file to set image working directory
+COPY ./shared/utils.mjs ./
+
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "start" ]

--- a/shared/test.txt
+++ b/shared/test.txt
@@ -1,1 +1,0 @@
-This is a textfile that will can be copied into different services after the build context change.

--- a/shared/utils.mjs
+++ b/shared/utils.mjs
@@ -1,0 +1,19 @@
+
+/**
+ * When an error happens in a promise, the promise is rejected. The possibility of rejection must be handled
+ * to avoid the deprecated UnhandledPromiseRejectionWarning, which will terminate the Node process in the future.
+ * This utility function handles possible rejections of passed promise.
+ * Returns a two element array [error, response], where the error is undefined if there is no error
+ * and response is undefined if there is an error or if the promise returned void.
+ * @param {Promise} promise The promise to handle
+ * @returns {Array} Returns a two element array [error | undefined, response | undefined] where one position is always undefined
+ */
+const promiseHandler = promise => {
+ return promise
+   .then(response => [undefined, response])
+   .catch(error => [error, undefined]);
+}
+
+export {
+  promiseHandler
+}


### PR DESCRIPTION
Copying a shared utils.mjs module into all containers that includes a function that can be used to handle promise rejections without cluttering the code with multiple try/catch blocks. This handler function is used on every promise in both Kafka and RabbitMQ services to always get back a two element array [error, response] where the error is undefined only if there is no error, making it easy to handle errors. The response is undefined if there is an error or if the promise returns void even if there is no error. 