### PR TITLE
Closes Issue#33

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -38,7 +38,7 @@ const getExperimentById = experimentId => {
  */
 const runExperiment = experimentId => {
   const experiment = getExperimentById(experimentId);
-  const { broker, producers, minutes } = experiment;
+  const { broker, producers, consumers, minutes } = experiment;
 
   // Update experiment status directly without waiting for the bash script to finish
   experiment.status = Status.STARTING;
@@ -47,7 +47,7 @@ const runExperiment = experimentId => {
   runningExperimentId = experimentId;
 
   const shFilePath = `./sh/${broker.toLowerCase()}-start-experiment.sh`;
-  const shArgs = [producers, minutes];
+  const shArgs = [producers, consumers, minutes];
 
   console.log(`Starting experiment with id ${experimentId}...`);
   execFile(shFilePath, shArgs, (err, stdout, stderr) => {
@@ -81,10 +81,10 @@ const stopExperiment = (experimentId, isForced = false) => {
   }
 
   const experiment = getExperimentById(experimentId);
-  const { broker, producers } = experiment;
+  const { broker, producers, consumers } = experiment;
 
   const shFilePath = `./sh/${broker.toLowerCase()}-stop-experiment.sh`;
-  const shArgs = [producers];
+  const shArgs = [producers, consumers];
 
   // Update experiment status directly without waiting for the bash script to finish
   experiment.status = Status.STOPPING;
@@ -309,6 +309,7 @@ app.post("/completed", (req, res) => {
 
 /**
  * This route is used to get requests from the consumer about experiment start after established broker connection
+ * @todo Probably want to log the time of countdown start on backend to be able to restore it on frontend on possible page refresh
  */
 app.post("/start", (req, res) => {
   const experiment = getExperimentById(runningExperimentId);

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -26,6 +26,7 @@
             <th data-sortable>Name ⇅</th>
             <th data-sortable>Broker ⇅</th>
             <th data-sortable data-integer>Producers ⇅</th>
+            <th data-sortable data-integer>Consumers ⇅</th>
             <th data-sortable data-integer>Minutes ⇅</th>
             <th data-sortable>Status ⇅</th>
             <th>Actions</th>
@@ -43,7 +44,10 @@
               </select>
             </td>
             <td>
-              <input type="number" form="new-experiment-form" name="producers" min="1" max="10" value="1" required>
+              <input type="number" form="new-experiment-form" name="producers" min="1" max="1000" value="1" required>
+            </td>
+            <td>
+              <input type="number" form="new-experiment-form" name="consumers" min="1" max="1000" value="1" required>
             </td>
             <td>
               <input type="number" form="new-experiment-form" name="minutes" min="1" max="10080" value="10" required>

--- a/dashboard/public/js/script.js
+++ b/dashboard/public/js/script.js
@@ -15,7 +15,7 @@ let Status = {};
 let experiments = [];
 let chartsByMetric = {};
 let dataset = {};
-let countdownInterval;
+let countdownInterval = null;
 let secondsFilterFrom = 15;
 let secondsFilterTo = 0;
 
@@ -153,6 +153,7 @@ const stopExperiment = async experimentId => {
   }
   experiments = data.experiments;
   clearInterval(countdownInterval);
+  countdownInterval = null;
   countdownElement.innerText = "00:00:00";
   saveToLocalStorage(EXPERIMENTS_KEY, experiments);
   renderExperimentsTable();
@@ -177,6 +178,7 @@ const renderExperimentsTable = () => {
       experimentName, 
       broker, 
       producers, 
+      consumers,
       minutes, 
       status 
     } = experiment;
@@ -192,6 +194,7 @@ const renderExperimentsTable = () => {
     const tdName = document.createElement("td");
     const tdBroker = document.createElement("td");
     const tdProducers = document.createElement("td");
+    const tdConsumers = document.createElement("td");
     const tdMinutes = document.createElement("td");
     const tdStatus = document.createElement("td");
     const buttonContainer = document.createElement("td");
@@ -199,6 +202,7 @@ const renderExperimentsTable = () => {
     tdName.innerText = experimentName;
     tdBroker.innerText = broker;
     tdProducers.innerText = producers;
+    tdConsumers.innerText = consumers;
     tdMinutes.innerText = minutes;
     tdStatus.innerText = status;
     buttonContainer.classList.add("button-container");
@@ -206,6 +210,7 @@ const renderExperimentsTable = () => {
     row.appendChild(tdName);
     row.appendChild(tdBroker);
     row.appendChild(tdProducers);
+    row.appendChild(tdConsumers);
     row.appendChild(tdMinutes);
     row.appendChild(tdStatus);
     row.appendChild(buttonContainer);
@@ -290,6 +295,7 @@ const startCountdown = (minutes = 10) => {
   
     if(timeLeft <= 0) {
       clearInterval(countdownInterval);
+      countdownInterval = null;
       countdownElement.innerText = "00:00:00";
       return;
     }
@@ -598,9 +604,11 @@ eventSource.addEventListener("message", e => {
  * The received data contains the number of minutes to countdown for.
  */
 eventSource.addEventListener("countdown", e => {
+  if(countdownInterval !== null) return;
   dataset = {}; // Empty dataset before experiment starts to prevent having old data in new experiment data
   const minutes = parseInt(JSON.parse(e.data).minutes);
   clearInterval(countdownInterval);
+  countdownInterval = null;
   startCountdown(minutes);
 });
 
@@ -638,6 +646,7 @@ newExperimentForm.addEventListener("submit", async e => {
   const experimentName = document.querySelector(`[name="experimentName"]`).value;
   const broker = document.querySelector(`[name="broker"]`).value;
   const producers = document.querySelector(`[name="producers"]`).value;
+  const consumers = document.querySelector(`[name="consumers"]`).value;
   const minutes = document.querySelector(`[name="minutes"]`).value;
 
   const experiment = {
@@ -645,6 +654,7 @@ newExperimentForm.addEventListener("submit", async e => {
     experimentName,
     broker,
     producers,
+    consumers,
     minutes,
     status: ""
   };

--- a/kafka/consumer-service/Dockerfile
+++ b/kafka/consumer-service/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${NODE_ENV}" = "development" ]; \
 COPY ./kafka/consumer-service/ ./
 
 # Copy shared utils file to shared directory of set image working directory
-COPY ./shared/utils.js ./shared/aggregations.js ./shared/
+COPY ./shared/ ./shared/
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "prod" ]

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -4,12 +4,17 @@ import { startExperiment } from "./shared/consumer-to-dashboard.js";
 import { createKafkaInstance } from "./shared/kafka-create-instance.js";
 import { createTopics } from "./shared/kafka-create-topics.js";
 
-const TOPIC_NAME = "air-quality-observation-topic";
+const {
+  TOPIC_NAME = "air-quality-observation-topic",
+  NUMBER_OF_PARTITIONS = 1,
+  CONSUMER_ID = "consumer-service-1",
+  CONSUMER_GROUP_ID = "test-consumer-group",
+} = process.env;
 
 (async () => {
-  const kafka = createKafkaInstance("consumer-service-1");
+  const kafka = createKafkaInstance(CONSUMER_ID);
   await createTopics(kafka);
-  const consumer = kafka.consumer({ groupId: "test-consumer-group" });
+  const consumer = kafka.consumer({ groupId: CONSUMER_GROUP_ID });
 
   const [connectionError] = await handler(consumer.connect());
   if(connectionError) {
@@ -24,6 +29,7 @@ const TOPIC_NAME = "air-quality-observation-topic";
 
   // Run consumer and handle one message at a time
   await handler(consumer.run({
+    partitionsConsumedConcurrently: parseInt(NUMBER_OF_PARTITIONS),
     eachMessage: async ({ topic, partition, message }) => {
       saveMessage(JSON.parse(message.value.toString()));
     }

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -1,22 +1,9 @@
 import { Kafka } from "kafkajs";
-import http from "http";
-import { 
-  promiseHandler as handler
-} from "./shared/utils.js";
-import {
-  aggregations,
-  saveMessage
-} from "./shared/aggregations.js";
+import { promiseHandler as handler } from "./shared/utils.js";
+import { saveMessage } from "./shared/aggregations.js";
+import { startExperiment } from "./shared/consumer-to-dashboard.js";
 
 const TOPIC_NAME = "air-quality-observation-topic";
-const EXPERIMENT_TIME_MS = (process.env.NUMBER_OF_MINUTES || 10) * 60 * 1000;
-const AGGREGATE_PUBLISH_RATE = process.env.AGGREGATE_PUBLISH_RATE || 1000;
-
-const commonRequestProperties = {
-  hostname: "dashboard-app",
-  port: 3000,
-  method: "POST",
-};
 
 const kafka = new Kafka({
   clientId: "consumer-service-1",
@@ -45,42 +32,9 @@ const consumer = kafka.consumer({
     console.log(`Successfully subscribed to topic ${TOPIC_NAME}!`);
   }
 
-  setInterval(() => {
-    const data = JSON.stringify(aggregations);
-    const request = http.request({
-      path: "/aggregations",
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": data.length
-      },
-      ...commonRequestProperties
-    });
-    request.write(data);
-    request.end();
+  // Start publish interval, experiment timeout and inform dashboard-backend
+  startExperiment();
 
-    // Empty aggregations after every time we send to dashboard backend
-    Object.keys(aggregations).forEach(stationId => delete aggregations[stationId]);
-
-  }, AGGREGATE_PUBLISH_RATE);
-
-  // A request to the dashboard backend for when the consumer will initialize its timeout function
-  // Used to make it possible to have a decently correct countdown on the frontend
-  {
-    const request = http.request({
-      path: "/start",
-      ...commonRequestProperties
-    });
-    request.end();
-  }
-
-  setTimeout(() => {
-    const request = http.request({
-      path: "/completed",
-      ...commonRequestProperties
-    });
-    request.end();
-  }, EXPERIMENT_TIME_MS);
-  
   // Run consumer and handle one message at a time
   await handler(consumer.run({
     eachMessage: async ({ topic, partition, message }) => {

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -1,36 +1,21 @@
-import { Kafka } from "kafkajs";
 import { promiseHandler as handler } from "./shared/utils.js";
 import { saveMessage } from "./shared/aggregations.js";
 import { startExperiment } from "./shared/consumer-to-dashboard.js";
+import { createKafkaInstance } from "./shared/kafka-create-instance.js";
 
 const TOPIC_NAME = "air-quality-observation-topic";
 
-const kafka = new Kafka({
-  clientId: "consumer-service-1",
-  brokers: [
-    "kafka-broker-1:9092"
-  ]
-});
-
-// Create a consumer that joins a consumer group (required)
-const consumer = kafka.consumer({
-  groupId: "test-consumer-group"
-});
-
 (async () => {
+  const kafka = createKafkaInstance("consumer-service-1");
+  const consumer = kafka.consumer({ groupId: "test-consumer-group" });
+
   const [connectionError] = await handler(consumer.connect());
   if(connectionError) {
     return console.error("Could not connect to Kafka...");
   }
 
-  // Subscribe consumer group to topic and start using latest offset
-  const [subscribeError] = await handler(consumer.subscribe({
-    topic: TOPIC_NAME,
-    fromBeginning: true
-  }));
-  if(!subscribeError) {
-    console.log(`Successfully subscribed to topic ${TOPIC_NAME}!`);
-  }
+  // Subscribe consumer group to topic
+  await handler(consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false }));
 
   // Start publish interval, experiment timeout and inform dashboard-backend
   startExperiment();
@@ -38,9 +23,6 @@ const consumer = kafka.consumer({
   // Run consumer and handle one message at a time
   await handler(consumer.run({
     eachMessage: async ({ topic, partition, message }) => {
-      //const { stationId, timestamp, coordinates, concentrations } = JSON.parse(message.value.toString());
-      //console.log(`Consumed air quality observation from station with id ${stationId}. MO=${message.offset}, P=${partition} T=${topic} K=${message.key.toString()}.`);
-
       saveMessage(JSON.parse(message.value.toString()));
     }
   }));

--- a/kafka/consumer-service/consumer-service.js
+++ b/kafka/consumer-service/consumer-service.js
@@ -2,11 +2,13 @@ import { promiseHandler as handler } from "./shared/utils.js";
 import { saveMessage } from "./shared/aggregations.js";
 import { startExperiment } from "./shared/consumer-to-dashboard.js";
 import { createKafkaInstance } from "./shared/kafka-create-instance.js";
+import { createTopics } from "./shared/kafka-create-topics.js";
 
 const TOPIC_NAME = "air-quality-observation-topic";
 
 (async () => {
   const kafka = createKafkaInstance("consumer-service-1");
+  await createTopics(kafka);
   const consumer = kafka.consumer({ groupId: "test-consumer-group" });
 
   const [connectionError] = await handler(consumer.connect());

--- a/kafka/producer-service/Dockerfile
+++ b/kafka/producer-service/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${NODE_ENV}" = "development" ]; \
 COPY ./kafka/producer-service/ ./
 
 # Copy shared utils file to shared directory of set image working directory
-COPY ./shared/utils.js ./shared/concentration-generator.js ./shared/concentration-statistics.js ./shared/
+COPY ./shared/ ./shared/
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "prod" ]

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -47,11 +47,7 @@ const defaultStationProperties = { stationId, coordinates: { lat, long } };
     }
 
     // Send air quality observation to Kafka topic
-    await handler(producer.send({
-      topic,
-      messages,
-      acks: -1
-    }));
+    await handler(producer.send({ topic, messages, acks: -1 }));
   }
 
   await handler(producer.disconnect());

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -2,6 +2,7 @@ import { CompressionTypes } from "kafkajs";
 import { promiseHandler as handler } from "./shared/utils.js";
 import { getConcentrations } from "./shared/concentration-generator.js";
 import { createKafkaInstance } from "./shared/kafka-create-instance.js";
+import { createTopics } from "./shared/kafka-create-topics.js";
 
 const {
   TOPIC_NAME = "air-quality-observation-topic",
@@ -18,6 +19,7 @@ const defaultStationProperties = { stationId, coordinates: { lat, long } };
 
 (async () => {
   const kafka = createKafkaInstance(stationId);
+  await createTopics(kafka);
   const producer = kafka.producer();
 
   // Some promises return void when resolving, making the response undefined and not necessary to destructure.

--- a/kafka/producer-service/producer-service.js
+++ b/kafka/producer-service/producer-service.js
@@ -1,31 +1,25 @@
-import { CompressionTypes, Kafka } from "kafkajs";
-import { 
-  promiseHandler as handler
-} from "./shared/utils.js";
+import { CompressionTypes } from "kafkajs";
+import { promiseHandler as handler } from "./shared/utils.js";
 import { getConcentrations } from "./shared/concentration-generator.js";
+import { createKafkaInstance } from "./shared/kafka-create-instance.js";
 
-const TOPIC_NAME = "air-quality-observation-topic";
+const {
+  TOPIC_NAME = "air-quality-observation-topic",
+  STATION_ID: stationId = "producer-service-1",
+  LAT: lat = 37.5665,
+  LONG: long = 126.9780
+} = process.env;
+
 let previousConcentrations;
 
 // Properties included in air quality data point that never changes for an air quality sensor station
 // Will be merged into each air quality data point
-const defaultStationProperties = {
-  stationId: process.env.STATION_ID || "producer-service-1",
-  coordinates: {
-    lat: process.env.LAT || 37.5665,
-    long: process.env.LONG || 126.9780
-  }
-}
-
-const kafka = new Kafka({
-  clientId: defaultStationProperties.stationId,
-  brokers: [ 
-    "kafka-broker-1:9092" 
-  ]
-});
-const producer = kafka.producer();
+const defaultStationProperties = { stationId, coordinates: { lat, long } };
 
 (async () => {
+  const kafka = createKafkaInstance(stationId);
+  const producer = kafka.producer();
+
   // Some promises return void when resolving, making the response undefined and not necessary to destructure.
   const [connectionError] = await handler(producer.connect());
   if(connectionError) {

--- a/rabbitmq/consumer-service/Dockerfile
+++ b/rabbitmq/consumer-service/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${NODE_ENV}" = "development" ]; \
 COPY ./rabbitmq/consumer-service/ ./
 
 # Copy shared utils file to set image working directory
-COPY ./shared/utils.js ./shared/rabbitmq-connect.js ./shared/aggregations.js ./shared/
+COPY ./shared/ ./shared/
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "prod" ]

--- a/rabbitmq/consumer-service/consumer-service.js
+++ b/rabbitmq/consumer-service/consumer-service.js
@@ -27,13 +27,12 @@ const { QUEUE_NAME = "air-quality-observation-queue" } = process.env;
 
   console.log(`Consuming messages from ${QUEUE_NAME}...`);
   const [consumeError, { consumerTag }] = await handler(channel.consume(QUEUE_NAME, (messageObject) => {
-    //console.log(`Consumed air quality observation.`);
     const message = JSON.parse(messageObject.content.toString());
     saveMessage(message);
 
     // Acknowledge successful message consumption to delete message from queue
-    channel.ack(messageObject);
-  }));
+    //channel.ack(messageObject);
+  }, { noAck: true }));
   if(consumeError) {
     console.log(`Could not consume from queue ${QUEUE_NAME}`);
   }

--- a/rabbitmq/consumer-service/consumer-service.js
+++ b/rabbitmq/consumer-service/consumer-service.js
@@ -3,7 +3,7 @@ import { connectToRabbitMQ } from "./shared/rabbitmq-connect.js";
 import { saveMessage } from "./shared/aggregations.js";
 import { startExperiment } from "./shared/consumer-to-dashboard.js";
 
-const QUEUE_NAME = "air-quality-observation-queue";
+const { QUEUE_NAME = "air-quality-observation-queue" } = process.env;
 
 (async () => {
   const [connectionError, connection] = await connectToRabbitMQ();

--- a/rabbitmq/consumer-service/consumer-service.js
+++ b/rabbitmq/consumer-service/consumer-service.js
@@ -1,17 +1,9 @@
-import http from "http";
 import { promiseHandler as handler } from "./shared/utils.js";
-import {  connectToRabbitMQ } from "./shared/rabbitmq-connect.js";
-import { aggregations, saveMessage } from "./shared/aggregations.js";
+import { connectToRabbitMQ } from "./shared/rabbitmq-connect.js";
+import { saveMessage } from "./shared/aggregations.js";
+import { startExperiment } from "./shared/consumer-to-dashboard.js";
 
 const QUEUE_NAME = "air-quality-observation-queue";
-const EXPERIMENT_TIME_MS = (process.env.NUMBER_OF_MINUTES || 10) * 60 * 1000;
-const AGGREGATE_PUBLISH_RATE = process.env.AGGREGATE_PUBLISH_RATE || 1000;
-
-const commonRequestProperties = {
-  hostname: "dashboard-app",
-  port: 3000,
-  method: "POST",
-};
 
 (async () => {
   const [connectionError, connection] = await connectToRabbitMQ();
@@ -30,41 +22,8 @@ const commonRequestProperties = {
     console.log("Could not create queue or assert queue existance.");
   }
   
-  setInterval(() => {
-    const data = JSON.stringify(aggregations);
-    const request = http.request({
-      path: "/aggregations",
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": data.length
-      },
-      ...commonRequestProperties
-    });
-    request.write(data);
-    request.end();
-
-    // Empty aggregations after every time we send to dashboard backend
-    Object.keys(aggregations).forEach(stationId => delete aggregations[stationId]);
-
-  }, AGGREGATE_PUBLISH_RATE);
-
-  // A request to the dashboard backend for when the consumer will initialize its timeout function
-  // Used to make it possible to have a decently correct countdown on the frontend
-  {
-    const request = http.request({
-      path: "/start",
-      ...commonRequestProperties
-    });
-    request.end();
-  }
-
-  setTimeout(() => {
-    const request = http.request({
-      path: "/completed",
-      ...commonRequestProperties
-    });
-    request.end();
-  }, EXPERIMENT_TIME_MS);
+  // Start publish interval, experiment timeout and inform dashboard-backend
+  startExperiment();
 
   console.log(`Consuming messages from ${QUEUE_NAME}...`);
   const [consumeError, { consumerTag }] = await handler(channel.consume(QUEUE_NAME, (messageObject) => {

--- a/rabbitmq/producer-service/Dockerfile
+++ b/rabbitmq/producer-service/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${NODE_ENV}" = "development" ]; \
 COPY ./rabbitmq/producer-service/ ./
 
 # Copy shared files to set image working directory
-COPY ./shared/utils.js ./shared/rabbitmq-connect.js ./shared/concentration-generator.js ./shared/concentration-statistics.js ./shared/
+COPY ./shared/ ./shared/
 
 # Command to execute when container instance is created based on image (starts application in container)
 CMD [ "npm", "run", "prod" ]

--- a/rabbitmq/producer-service/producer-service.js
+++ b/rabbitmq/producer-service/producer-service.js
@@ -2,22 +2,22 @@ import { promiseHandler as handler } from "./shared/utils.js";
 import { connectToRabbitMQ } from "./shared/rabbitmq-connect.js";
 import { getConcentrations } from "./shared/concentration-generator.js";
 
-const EXCHANGE_NAME = "air-quality-observation-exchange";
-const EXCHANGE_TYPE = "direct";
-const QUEUE_NAME = "air-quality-observation-queue";
-const BINDING_KEY = "air-quality-observation-binding";
+const {
+  QUEUE_NAME = "air-quality-observation-queue",
+  EXCHANGE_NAME = "air-quality-observation-exchange",
+  EXCHANGE_TYPE = "direct",
+  BINDING_KEY = "air-quality-observation-binding",
+  STATION_ID: stationId = "producer-service-1",
+  LAT: lat = 37.5665,
+  LONG: long = 126.9780
+} = process.env;
 const ROUTING_KEY = BINDING_KEY;
+
 let previousConcentrations;
 
 // Properties included in air quality data point that never changes for an air quality sensor station
 // Will be merged into each air quality data point
-const defaultStationProperties = {
-  stationId: process.env.STATION_ID || "producer-service-1",
-  coordinates: {
-    lat: process.env.LAT || 37.5665,
-    long: process.env.LONG || 126.9780
-  }
-};
+const defaultStationProperties = { stationId, coordinates: { lat, long } };
 
 (async () => {
   const [connectionError, connection] = await connectToRabbitMQ();

--- a/sh/kafka-start-experiment.sh
+++ b/sh/kafka-start-experiment.sh
@@ -5,47 +5,76 @@ PRODUCERS=${1:-1} # The number of producer containers to spin up (First argument
 CONSUMERS=${2:-1} # The number of consumer containers to spin up
 MINUTES=${3:-10} # The number of minutes the experiment should run
 
+# Zookeeper and broker settings
+ZOOKEEPER_HOSTNAME=zookeeper-node-1
+ZOOKEEPER_PORT=2181
+BROKER_NAME=kafka-broker-1
+BROKER_INTERNAL_PORT=9092
+BROKER_EXTERNAL_PORT=19092
+
+# All brokers to send to producers and consumers (separated by commas if multi broker cluster)
+BROKERS=$BROKER_NAME:$BROKER_INTERNAL_PORT
+
 # Topic creation
 TOPIC_NAME=air-quality-observation-topic
-NUMBER_OF_PARTITIONS=10
+NUMBER_OF_PARTITIONS=$CONSUMERS
 REPLICATION_FACTOR=1
+
+# Used by consumer container only
+CONSUMER_GROUP_ID=test-consumer-group
+DASHBOARD_HOSTNAME=dashboard-app
+DASHBOARD_PORT=3000
+AGGREGATION_RATE=1000
+AGGREGATE_PUBLISH_RATE=1000
+
+# Used by producer container only
+LAT=37.5665
+LONG=126.9780
+
+# Commong network that all containers join
+NETWORK=common-network
 
 # Create and run Zookeeper container based on official Zookeeper image from Docker Hub
 docker run -d \
---name zookeeper-node-1 \
--h zookeeper-node-1 \
--p 2181:2181 \
+--name $ZOOKEEPER_HOSTNAME \
+-h $ZOOKEEPER_HOSTNAME \
+-p $ZOOKEEPER_PORT:$ZOOKEEPER_PORT \
 -e ZOO_MY_ID=1 \
---net common-network \
+--net $NETWORK \
 zookeeper:3.6.2
 
 # Create and run Kafka container based on popular Apache Kafka Docker image that downloads Kafka from Apache's official Kafka website
 # Kafka version specified by tag in format: <scala version>-<kafka version>
-# Create topic with 10 partitions and replication factor 1 if it does not already exists (special for the wurstmeister Kafka image)
-# Could have used the kafkajs admin client to create the topic instead
 docker run -d \
---name kafka-broker-1 \
--p 19092:19092 \
--e KAFKA_ZOOKEEPER_CONNECT=zookeeper-node-1:2181 \
+--name $BROKER_NAME \
+-p $BROKER_EXTERNAL_PORT:$BROKER_EXTERNAL_PORT \
+-e KAFKA_ZOOKEEPER_CONNECT=$ZOOKEEPER_HOSTNAME:$ZOOKEEPER_PORT \
 -e KAFKA_BROKER_ID=1 \
--e KAFKA_LISTENERS=INTERNAL://kafka-broker-1:9092,EXTERNAL://kafka-broker-1:19092 \
--e KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka-broker-1:9092,EXTERNAL://localhost:19092 \
+-e KAFKA_LISTENERS=INTERNAL://$BROKER_NAME:$BROKER_INTERNAL_PORT,EXTERNAL://$BROKER_NAME:$BROKER_EXTERNAL_PORT \
+-e KAFKA_ADVERTISED_LISTENERS=INTERNAL://$BROKER_NAME:$BROKER_INTERNAL_PORT,EXTERNAL://localhost:$BROKER_EXTERNAL_PORT \
 -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
 -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
 -e KAFKA_AUTO_CREATE_TOPICS_ENABLE=false \
---net common-network \
+--net $NETWORK \
 wurstmeister/kafka:2.13-2.7.0
 
-# Create and run a number of Kafka consumer containers depending on passed argument
+# Create and run one container instance of the Kafka consumer image
 for ((i = 1; i <= $CONSUMERS; i++))
 do
   docker run -d \
   --name kafka-consumer-service-$i \
   -e NUMBER_OF_MINUTES=$MINUTES \
+  -e CONSUMER_ID=consumer-service-$i \
+  -e CONSUMER_GROUP_ID=$CONSUMER_GROUP_ID \
   -e TOPIC_NAME=$TOPIC_NAME \
   -e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
   -e REPLICATION_FACTOR=$REPLICATION_FACTOR \
-  --net common-network \
+  -e DASHBOARD_HOSTNAME=$DASHBOARD_HOSTNAME \
+  -e DASHBOARD_PORT=$DASHBOARD_PORT \
+  -e AGGREGATION_RATE=$AGGREGATION_RATE \
+  -e AGGREGATE_PUBLISH_RATE=$AGGREGATE_PUBLISH_RATE \
+  -e BROKERS=$BROKERS \
+  --net $NETWORK \
   kafka-consumer-image
 done
 
@@ -58,6 +87,9 @@ do
   -e TOPIC_NAME=$TOPIC_NAME \
   -e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
   -e REPLICATION_FACTOR=$REPLICATION_FACTOR \
-  --net common-network \
+  -e LAT=$LAT \
+  -e LONG=$LONG \
+  -e BROKERS=$BROKERS \
+  --net $NETWORK \
   kafka-producer-image
 done

--- a/sh/kafka-start-experiment.sh
+++ b/sh/kafka-start-experiment.sh
@@ -30,7 +30,7 @@ AGGREGATE_PUBLISH_RATE=1000
 # Used by producer container only
 LAT=37.5665
 LONG=126.9780
-MESSAGES_PER_BATCH=24
+MESSAGES_PER_BATCH=1024
 
 # Commong network that all containers join
 NETWORK=common-network

--- a/sh/kafka-start-experiment.sh
+++ b/sh/kafka-start-experiment.sh
@@ -4,6 +4,11 @@
 PRODUCERS=${1:-1} # The number of producer containers to spin up (First argument passed to script or default if not passed)
 MINUTES=${2:-10} # The number of miuntes the experiment should run
 
+# Topic creation
+TOPIC_NAME=air-quality-observation-topic
+NUMBER_OF_PARTITIONS=10
+REPLICATION_FACTOR=1
+
 # Create and run Zookeeper container based on official Zookeeper image from Docker Hub
 docker run -d \
 --name zookeeper-node-1 \
@@ -26,7 +31,7 @@ docker run -d \
 -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka-broker-1:9092,EXTERNAL://localhost:19092 \
 -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
 -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
--e KAFKA_CREATE_TOPICS=air-quality-observation-topic:10:1 \
+-e KAFKA_AUTO_CREATE_TOPICS_ENABLE=false \
 --net common-network \
 wurstmeister/kafka:2.13-2.7.0
 
@@ -34,6 +39,9 @@ wurstmeister/kafka:2.13-2.7.0
 docker run -d \
 --name kafka-consumer-service-1 \
 -e NUMBER_OF_MINUTES=$MINUTES \
+-e TOPIC_NAME=$TOPIC_NAME \
+-e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
+-e REPLICATION_FACTOR=$REPLICATION_FACTOR \
 --net common-network \
 kafka-consumer-image
 
@@ -43,6 +51,9 @@ do
   docker run -d \
   --name kafka-producer-service-$i \
   -e STATION_ID=producer-service-$i \
+  -e TOPIC_NAME=$TOPIC_NAME \
+  -e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
+  -e REPLICATION_FACTOR=$REPLICATION_FACTOR \
   --net common-network \
   kafka-producer-image
 done

--- a/sh/kafka-start-experiment.sh
+++ b/sh/kafka-start-experiment.sh
@@ -2,7 +2,8 @@
 
 # Parameters passed into the script
 PRODUCERS=${1:-1} # The number of producer containers to spin up (First argument passed to script or default if not passed)
-MINUTES=${2:-10} # The number of miuntes the experiment should run
+CONSUMERS=${2:-1} # The number of consumer containers to spin up
+MINUTES=${3:-10} # The number of minutes the experiment should run
 
 # Topic creation
 TOPIC_NAME=air-quality-observation-topic
@@ -35,15 +36,18 @@ docker run -d \
 --net common-network \
 wurstmeister/kafka:2.13-2.7.0
 
-# Create and run one container instance of the Kafka consumer image
-docker run -d \
---name kafka-consumer-service-1 \
--e NUMBER_OF_MINUTES=$MINUTES \
--e TOPIC_NAME=$TOPIC_NAME \
--e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
--e REPLICATION_FACTOR=$REPLICATION_FACTOR \
---net common-network \
-kafka-consumer-image
+# Create and run a number of Kafka consumer containers depending on passed argument
+for ((i = 1; i <= $CONSUMERS; i++))
+do
+  docker run -d \
+  --name kafka-consumer-service-$i \
+  -e NUMBER_OF_MINUTES=$MINUTES \
+  -e TOPIC_NAME=$TOPIC_NAME \
+  -e NUMBER_OF_PARTITIONS=$NUMBER_OF_PARTITIONS \
+  -e REPLICATION_FACTOR=$REPLICATION_FACTOR \
+  --net common-network \
+  kafka-consumer-image
+done
 
 # Create and run a number of Kafka producer containers depending on passed argument
 for ((i = 1; i <= $PRODUCERS; i++))

--- a/sh/kafka-start-experiment.sh
+++ b/sh/kafka-start-experiment.sh
@@ -30,6 +30,7 @@ AGGREGATE_PUBLISH_RATE=1000
 # Used by producer container only
 LAT=37.5665
 LONG=126.9780
+MESSAGES_PER_BATCH=24
 
 # Commong network that all containers join
 NETWORK=common-network
@@ -90,6 +91,7 @@ do
   -e LAT=$LAT \
   -e LONG=$LONG \
   -e BROKERS=$BROKERS \
+  -e MESSAGES_PER_BATCH=$MESSAGES_PER_BATCH \
   --net $NETWORK \
   kafka-producer-image
 done

--- a/sh/kafka-stop-experiment.sh
+++ b/sh/kafka-stop-experiment.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 PRODUCERS=${1:-1} # The number of producer containers that should be stopped and removed
+CONSUMERS=${2:-1} # The number of consumer containers that should be stopped and removed
+
+# Remove all consumer containers by force
+for ((i = 1; i <= $CONSUMERS; i++))
+do
+  docker rm -f kafka-consumer-service-$i
+done
 
 # Remove all producer containers by force
 for ((i = 1; i <= $PRODUCERS; i++))
@@ -10,6 +17,5 @@ done
 
 # Forecefully remove the rest of the containers related to a Kafka experiement
 # Another option would be to stop them first and then remove them
-docker rm -f kafka-consumer-service-1
 docker rm -f kafka-broker-1
 docker rm -f zookeeper-node-1

--- a/sh/rabbitmq-start-experiment.sh
+++ b/sh/rabbitmq-start-experiment.sh
@@ -5,22 +5,64 @@ PRODUCERS=${1:-1} # The number of producer containers to spin up (First argument
 CONSUMERS=${2:-1} # The number of consumer containers to spin up
 MINUTES=${3:-10} # The number of miuntes the experiment should run
 
-# Create and run RabbitMQ container based on the official RabbitMQ image including management UI.
-docker run -d \
---name rabbit-node-1 \
--h rabbit-node-1 \
--p 5672:5672 \
--p 15672:15672 \
---net common-network \
-rabbitmq:3.8.14-management
+# RabbitMQ connection settings
+PROTOCOL=amqp
+HOSTNAME=rabbitmq-node-1
+PORT=5672
+USERNAME=guest
+PASSWORD=guest
+VHOST=/
 
-# Create and run a number of RabbitMQ consumer containers depending on passed argument
+# RabbitMQ connection retry settings
+SECONDS_BETWEEN_CONNECTION_RETRIES=2
+MAXIMUM_NUMBER_OF_RETRIES=30
+
+# Queue/Exchange/Binding
+QUEUE_NAME=air-quality-observation-queue
+EXCHANGE_NAME=air-quality-observation-exchange
+EXCHANGE_TYPE=direct
+BINDING_KEY=air-quality-observation-binding
+
+# Used by consumer container only
+DASHBOARD_HOSTNAME=dashboard-app
+DASHBOARD_PORT=3000
+AGGREGATION_RATE=1000
+AGGREGATE_PUBLISH_RATE=1000
+
+# Commong network that all containers join
+NETWORK=common-network
+
+# Create and run RabbitMQ container based on the official RabbitMQ image
+docker run -d \
+--name $HOSTNAME \
+-h $HOSTNAME \
+-p $PORT:$PORT \
+-e RABBITMQ_DEFAULT_USER=$PASSWORD \
+-e RABBITMQ_DEFAULT_PASS=$USERNAME \
+-e RABBITMQ_DEFAULT_VHOST=$VHOST \
+--net $NETWORK \
+rabbitmq:3.8.14
+
+# Create and run one container instance of the RabbitMQ consumer image
 for ((i = 1; i <= $CONSUMERS; i++))
 do
   docker run -d \
   --name rabbitmq-consumer-service-$i \
   -e NUMBER_OF_MINUTES=$MINUTES \
-  --net common-network \
+  -e QUEUE_NAME=$QUEUE_NAME \
+  -e AGGREGATION_RATE=$AGGREGATION_RATE \
+  -e AGGREGATE_PUBLISH_RATE=$AGGREGATE_PUBLISH_RATE \
+  -e DASHBOARD_HOSTNAME=$DASHBOARD_HOSTNAME \
+  -e DASHBOARD_PORT=$DASHBOARD_PORT \
+  -e SECONDS_BETWEEN_CONNECTION_RETRIES=$SECONDS_BETWEEN_CONNECTION_RETRIES \
+  -e MAXIMUM_NUMBER_OF_RETRIES=$MAXIMUM_NUMBER_OF_RETRIES \
+  -e PROTOCOL=$PROTOCOL \
+  -e HOSTNAME=$HOSTNAME \
+  -e PORT=$PORT \
+  -e USERNAME=$USERNAME \
+  -e PASSWORD=$PASSWORD \
+  -e VHOST=$VHOST \
+  --net $NETWORK \
   rabbitmq-consumer-image
 done
 
@@ -30,6 +72,20 @@ do
   docker run -d \
   --name rabbitmq-producer-service-$i \
   -e STATION_ID=producer-service-$i \
-  --net common-network \
+  -e QUEUE_NAME=$QUEUE_NAME \
+  -e EXCHANGE_NAME=$EXCHANGE_NAME \
+  -e EXCHANGE_TYPE=$EXCHANGE_TYPE \
+  -e BINDING_KEY=$BINDING_KEY \
+  -e LAT=$LAT \
+  -e LONG=$LONG \
+  -e SECONDS_BETWEEN_CONNECTION_RETRIES=$SECONDS_BETWEEN_CONNECTION_RETRIES \
+  -e MAXIMUM_NUMBER_OF_RETRIES=$MAXIMUM_NUMBER_OF_RETRIES \
+  -e PROTOCOL=$PROTOCOL \
+  -e HOSTNAME=$HOSTNAME \
+  -e PORT=$PORT \
+  -e USERNAME=$USERNAME \
+  -e PASSWORD=$PASSWORD \
+  -e VHOST=$VHOST \
+  --net $NETWORK \
   rabbitmq-producer-image
 done

--- a/sh/rabbitmq-start-experiment.sh
+++ b/sh/rabbitmq-start-experiment.sh
@@ -2,7 +2,8 @@
 
 # Parameters passed into the script
 PRODUCERS=${1:-1} # The number of producer containers to spin up (First argument passed to script or default if not passed)
-MINUTES=${2:-10} # The number of miuntes the experiment should run
+CONSUMERS=${2:-1} # The number of consumer containers to spin up
+MINUTES=${3:-10} # The number of miuntes the experiment should run
 
 # Create and run RabbitMQ container based on the official RabbitMQ image including management UI.
 docker run -d \
@@ -13,12 +14,15 @@ docker run -d \
 --net common-network \
 rabbitmq:3.8.14-management
 
-# Create and run one container instance of the RabbitMQ consumer image
-docker run -d \
---name rabbitmq-consumer-service-1 \
--e NUMBER_OF_MINUTES=$MINUTES \
---net common-network \
-rabbitmq-consumer-image
+# Create and run a number of RabbitMQ consumer containers depending on passed argument
+for ((i = 1; i <= $CONSUMERS; i++))
+do
+  docker run -d \
+  --name rabbitmq-consumer-service-$i \
+  -e NUMBER_OF_MINUTES=$MINUTES \
+  --net common-network \
+  rabbitmq-consumer-image
+done
 
 # Create and run a number of RabbitMQ producer containers depending on passed argument
 for ((i = 1; i <= $PRODUCERS; i++))

--- a/sh/rabbitmq-start-experiment.sh
+++ b/sh/rabbitmq-start-experiment.sh
@@ -18,10 +18,11 @@ SECONDS_BETWEEN_CONNECTION_RETRIES=2
 MAXIMUM_NUMBER_OF_RETRIES=30
 
 # Queue/Exchange/Binding
+NUMBER_OF_QUEUES=$CONSUMERS
 QUEUE_NAME=air-quality-observation-queue
 EXCHANGE_NAME=air-quality-observation-exchange
 EXCHANGE_TYPE=direct
-BINDING_KEY=air-quality-observation-binding
+BINDING_KEY=$QUEUE_NAME
 
 # Used by consumer container only
 DASHBOARD_HOSTNAME=dashboard-app
@@ -50,6 +51,7 @@ do
   --name rabbitmq-consumer-service-$i \
   -e NUMBER_OF_MINUTES=$MINUTES \
   -e QUEUE_NAME=$QUEUE_NAME \
+  -e NUMBER_OF_QUEUES=$NUMBER_OF_QUEUES \
   -e AGGREGATION_RATE=$AGGREGATION_RATE \
   -e AGGREGATE_PUBLISH_RATE=$AGGREGATE_PUBLISH_RATE \
   -e DASHBOARD_HOSTNAME=$DASHBOARD_HOSTNAME \
@@ -73,6 +75,7 @@ do
   --name rabbitmq-producer-service-$i \
   -e STATION_ID=producer-service-$i \
   -e QUEUE_NAME=$QUEUE_NAME \
+  -e NUMBER_OF_QUEUES=$NUMBER_OF_QUEUES \
   -e EXCHANGE_NAME=$EXCHANGE_NAME \
   -e EXCHANGE_TYPE=$EXCHANGE_TYPE \
   -e BINDING_KEY=$BINDING_KEY \

--- a/sh/rabbitmq-stop-experiment.sh
+++ b/sh/rabbitmq-stop-experiment.sh
@@ -16,4 +16,4 @@ do
 done
 
 # Forecefully remove the rest of the containers related to a RabbitMQ experiment
-docker rm -f rabbit-node-1
+docker rm -f rabbitmq-node-1

--- a/sh/rabbitmq-stop-experiment.sh
+++ b/sh/rabbitmq-stop-experiment.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 PRODUCERS=${1:-1} # The number of producer containers that should be stopped and removed
+CONSUMERS=${2:-1} # The number of consumer containers that should be stopped and removed
+
+# Remove all consumer containers by force
+for ((i = 1; i <= $CONSUMERS; i++))
+do
+  docker rm -f rabbitmq-consumer-service-$i
+done
 
 # Remove all producer containers by force
 for ((i = 1; i <= $PRODUCERS; i++))
@@ -9,6 +16,4 @@ do
 done
 
 # Forecefully remove the rest of the containers related to a RabbitMQ experiment
-# Another option would be to stop them first and then remove them
-docker rm -f rabbitmq-consumer-service-1
 docker rm -f rabbit-node-1

--- a/shared/consumer-to-dashboard.js
+++ b/shared/consumer-to-dashboard.js
@@ -1,0 +1,68 @@
+import http from "http";
+import { aggregations } from "./aggregations.js";
+
+const {
+  DASHBOARD_HOSTNAME = "dashboard-app",
+  DASHBOARD_PORT = 3000,
+  NUMBER_OF_MINUTES = 10,
+  AGGREGATE_PUBLISH_RATE = 1000
+} = process.env;
+const EXPERIMENT_TIME_MS = NUMBER_OF_MINUTES * 60 * 1000;
+
+const commonRequestProperties = {
+  hostname: DASHBOARD_HOSTNAME,
+  port: DASHBOARD_PORT,
+  method: "POST"
+};
+
+let publishInterval = null
+let completionTimeout = null;
+
+/**
+ * Publishes the currently available aggregations to the dashboard-backend and empties the aggregations afterwards.
+ */
+const publish = () => {
+  const data = JSON.stringify(aggregations);
+  const request = http.request({
+    path: "/aggregations",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": data.length
+    },
+    ...commonRequestProperties
+  });
+  request.write(data);
+  request.end();
+
+  // Empty aggregations after every time we send to dashboard backend
+  Object.keys(aggregations).forEach(stationId => delete aggregations[stationId]);
+}
+
+/**
+ * Informs the dashboard-backend that the experiment has been completed by running for set amount of time.
+ */
+const informComplete = () => {
+  clearInterval(publishInterval);
+  const request = http.request({
+    path: "/completed",
+    ...commonRequestProperties
+  });
+  request.end();
+}
+
+/**
+ * Sets an interval that publishes messages to the dashboard-backend in intervals.
+ * Sets a timeout for when the experiment should finish.
+ * Informs the dashboard-backend that the consumer has initialized its experiment timer.
+ * Used to make it possible to have a decently correct countdown on the frontend.
+ */
+export const startExperiment = () => {
+  publishInterval = setInterval(publish, AGGREGATE_PUBLISH_RATE);
+  completionTimeout = setTimeout(informComplete, EXPERIMENT_TIME_MS);
+
+  const request = http.request({
+    path: "/start",
+    ...commonRequestProperties
+  });
+  request.end();
+}

--- a/shared/kafka-create-instance.js
+++ b/shared/kafka-create-instance.js
@@ -1,0 +1,15 @@
+import { Kafka } from "kafkajs";
+
+const { BROKERS = "kafka-broker-1:9092" } = process.env;
+
+// In case a multi-broker cluster is setup
+const brokers = BROKERS.split(",");
+
+/**
+ * Creates a new Kafka class instance for a specific service
+ * @param {String} clientId The id of the service that connects to Kafka
+ * @returns {Kafka} An instance of the Kafka class
+ */
+export const createKafkaInstance = clientId => {
+  return new Kafka({ clientId, brokers });
+}

--- a/shared/kafka-create-topics.js
+++ b/shared/kafka-create-topics.js
@@ -2,8 +2,8 @@ import { promiseHandler as handler } from "./utils.js";
 
 const {
   TOPIC_NAME: topic = "air-quality-observation-topic",
-  NUMBER_OF_PARTITIONS: numPartitions = 1,
-  REPLICATION_FACTOR: replicationFactor = 1
+  NUMBER_OF_PARTITIONS = 1,
+  REPLICATION_FACTOR = 1
 } = process.env;
 
 /**
@@ -21,8 +21,8 @@ export const createTopics = async kafka => {
   const [createError, isCreated] = await handler(admin.createTopics({
     topics: [{
       topic,
-      numPartitions,
-      replicationFactor
+      numPartitions: parseInt(NUMBER_OF_PARTITIONS),
+      replicationFactor: parseInt(REPLICATION_FACTOR)
     }]
   }));
 

--- a/shared/kafka-create-topics.js
+++ b/shared/kafka-create-topics.js
@@ -1,0 +1,38 @@
+import { promiseHandler as handler } from "./utils.js";
+
+const {
+  TOPIC_NAME: topic = "air-quality-observation-topic",
+  NUMBER_OF_PARTITIONS: numPartitions = 1,
+  REPLICATION_FACTOR: replicationFactor = 1
+} = process.env;
+
+/**
+ * Uses the Kafka.js admin client to create the Kafka topic that will be used.
+ * @param {Kafka} kafka An instance of the Kafka class
+ */
+export const createTopics = async kafka => {
+  const admin = kafka.admin();
+
+  const [connectionError] = await handler(admin.connect());
+  if(connectionError) {
+    return console.log("Could not connect to Kafka...");
+  }
+
+  const [createError, isCreated] = await handler(admin.createTopics({
+    topics: [{
+      topic,
+      numPartitions,
+      replicationFactor
+    }]
+  }));
+
+  await handler(admin.disconnect());
+
+  if(createError) {
+    return console.log("Error creating topics.");
+  }
+  if(!isCreated) {
+    return console.log("Topics already exists.");
+  }
+  console.log("Created topics.");
+}

--- a/shared/rabbitmq-connect.js
+++ b/shared/rabbitmq-connect.js
@@ -1,26 +1,24 @@
 import amqp from "amqplib";
 import { promiseHandler as handler, delay } from "./utils.js";
 
-const SECONDS_BETWEEN_CONNECTION_RETRIES = 2;
-const MAXIMUM_NUMBER_OF_RETRIES = 30;
+const {
+  PROTOCOL: protocol = "amqp",
+  HOSTNAME: hostname = "rabbitmq-node-1",
+  PORT: port = 5672,
+  USERNAME: username = "guest",
+  PASSWORD: password = "guest",
+  VHOST: vhost = "/",
+  SECONDS_BETWEEN_CONNECTION_RETRIES = 2,
+  MAXIMUM_NUMBER_OF_RETRIES = 30
+} = process.env;
 
 /**
  * The settings object used to connect to RabbitMQ with AMQP
  */
-const amqpConnectionSettings = {
-  protocol: "amqp",
-  hostname: "rabbit-node-1",
-  port: 5672,
-  username: "guest",
-  password: "guest",
-  vhost: "/",
-};
+const amqpConnectionSettings = { protocol, hostname, port, username, password, vhost };
 
 /**
  * Recursive function that attempts to connect to RabbitMQ until a successful connection is made.
- * @param {Object} amqpConnectionSettings The object with settings used when trying to conenct to RabbitMQ
- * @param {Number} SECONDS_BETWEEN_CONNECTION_RETRIES The number of seconds to delay between retries
- * @param {Number} MAXIMUM_NUMBER_OF_RETRIES The maximum number of connection retries before exiting recursive function with an error
  * @param {Number} retryNumber The current retry attempt number
  * @returns {Array} Two element array where the first position is the possible connection error and second position is the RabbitMQ connection
  */


### PR DESCRIPTION
Now it is possible to choose the number of consumers that will be started for an experiment. For Kafka, the number of partitions that the created topic that we produce to and consume from will have depends on an environment variable that currently is set to the number of consumers the experiment will have. This means that each consumer will always only consume from only one partition. A producer sends messages to any partition in a round robin manner. 
For RabbitMQ, the number of queues can be configured with an environment variable, which currently is set to the number of consumers. Each queue is bound to the exchange differently which makes it possible to collect all possible binding keys and randomly select one of them as the routing key each time a message is sent. The exchange will then route the message to the correct queue. Every consumer currently consumes from every available queue. This just makes sure that the queue is not the bottleneck, since https://www.cloudamqp.com/blog/part2-rabbitmq-best-practice-for-high-performance.html#:~:text=%20Part%202%3A%20RabbitMQ%20Best%20Practice%20for%20High,RabbitMQ%20HiPE%20%28still%20marked%20as%20expe...%20More%20 discusses that queue performance is limited to one CPU core.

Also moved some duplicated code into shared files that are imported and made heavy use of environment variables to make it possible to configure everything inside of the bash scripts.